### PR TITLE
Add missing alias to `PredictiveEntropy`

### DIFF
--- a/uncertainty_wizard/quantifiers/predictive_entropy.py
+++ b/uncertainty_wizard/quantifiers/predictive_entropy.py
@@ -44,7 +44,7 @@ class PredictiveEntropy(UncertaintyQuantifier):
     # docstr-coverage:inherited
     @classmethod
     def aliases(cls) -> List[str]:
-        return ["predictive_entropy", "pred_entropy"]
+        return ["predictive_entropy", "pred_entropy", "PE"]
 
     # docstr-coverage:inherited
     @classmethod


### PR DESCRIPTION
The docs (https://uncertainty-wizard.readthedocs.io/en/latest/user_guide_quantifiers.html) mention "PE" as alias for predictive entropy, but it was not actually implemented. I now added the alias.