### PR TITLE
:bug: fix multi-gpu issues 

### DIFF
--- a/examples/multi_device.py
+++ b/examples/multi_device.py
@@ -11,9 +11,6 @@ import uncertainty_wizard as uwiz
 
 class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManager):
 
-    #
-    # def __init__(self, *args, **kwargs):
-    #     super().__init__()
 
     @classmethod
     def file_path(cls) -> str:

--- a/examples/multi_device.py
+++ b/examples/multi_device.py
@@ -10,7 +10,6 @@ import uncertainty_wizard as uwiz
 
 
 class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManagerV2):
-
     @classmethod
     def file_path(cls) -> str:
         return "temp-ensemble.txt"
@@ -27,39 +26,63 @@ class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManagerV2
         # Here, we configure a setting with two gpus
         # On gpu 0, two atomic models will be executed at the same time
         # On gpu 1, three atomic models will be executed at the same time
-        return {
-            0: 2,
-            1: 3
-        }
+        return {0: 2, 1: 3}
 
 
 def train_model(model_id):
     import tensorflow as tf
 
     model = tf.keras.models.Sequential()
-    model.add(tf.keras.layers.Conv2D(32, kernel_size=(3, 3), activation='relu', padding='same',
-                                     input_shape=(32, 32, 3)))
-    model.add(tf.keras.layers.Conv2D(32, kernel_size=(3, 3), activation='relu', padding='same'))
+    model.add(
+        tf.keras.layers.Conv2D(
+            32,
+            kernel_size=(3, 3),
+            activation="relu",
+            padding="same",
+            input_shape=(32, 32, 3),
+        )
+    )
+    model.add(
+        tf.keras.layers.Conv2D(
+            32, kernel_size=(3, 3), activation="relu", padding="same"
+        )
+    )
     model.add(tf.keras.layers.MaxPooling2D((2, 2)))
     model.add(tf.keras.layers.Dropout(0.2))
-    model.add(tf.keras.layers.Conv2D(64, kernel_size=(3, 3), activation='relu', padding='same'))
-    model.add(tf.keras.layers.Conv2D(64, kernel_size=(3, 3), activation='relu', padding='same'))
+    model.add(
+        tf.keras.layers.Conv2D(
+            64, kernel_size=(3, 3), activation="relu", padding="same"
+        )
+    )
+    model.add(
+        tf.keras.layers.Conv2D(
+            64, kernel_size=(3, 3), activation="relu", padding="same"
+        )
+    )
     model.add(tf.keras.layers.MaxPooling2D((2, 2)))
     model.add(tf.keras.layers.Dropout(0.2))
-    model.add(tf.keras.layers.Conv2D(128, kernel_size=(3, 3), activation='relu', padding='same'))
-    model.add(tf.keras.layers.Conv2D(128, kernel_size=(3, 3), activation='relu', padding='same'))
+    model.add(
+        tf.keras.layers.Conv2D(
+            128, kernel_size=(3, 3), activation="relu", padding="same"
+        )
+    )
+    model.add(
+        tf.keras.layers.Conv2D(
+            128, kernel_size=(3, 3), activation="relu", padding="same"
+        )
+    )
     model.add(tf.keras.layers.MaxPooling2D((2, 2)))
     model.add(tf.keras.layers.Dropout(0.2))
     model.add(tf.keras.layers.Flatten())
-    model.add(tf.keras.layers.Dense(128, activation='relu'))
+    model.add(tf.keras.layers.Dense(128, activation="relu"))
     model.add(tf.keras.layers.Dropout(0.2))
-    model.add(tf.keras.layers.Dense(10, activation='softmax'))
+    model.add(tf.keras.layers.Dense(10, activation="softmax"))
 
     opt = tf.keras.optimizers.SGD(lr=0.001, momentum=0.9)
-    model.compile(optimizer=opt, loss='categorical_crossentropy', metrics=['accuracy'])
+    model.compile(optimizer=opt, loss="categorical_crossentropy", metrics=["accuracy"])
 
     (x_train, y_train), (_, _) = tf.keras.datasets.cifar10.load_data()
-    x_train = x_train / 255.
+    x_train = x_train / 255.0
     y_train = tf.keras.utils.to_categorical(y_train, 10)
 
     # For the sake of this example, let's use just one epoch.
@@ -69,7 +92,7 @@ def train_model(model_id):
     return model, "history_not_returned"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Make sure the training data is cached on the fs before the multiprocessing starts
     # Otherwise, all processes will simultaneously attempt to download and cache data,
     # which will fail as they break each others caches
@@ -77,8 +100,12 @@ if __name__ == '__main__':
 
     # set this path to where you want to save the ensemble
     temp_dir = "/tmp/ensemble"
-    ensemble = uwiz.models.LazyEnsemble(num_models=20, model_save_path=temp_dir, delete_existing=True,
-                                        default_num_processes=5)
+    ensemble = uwiz.models.LazyEnsemble(
+        num_models=20,
+        model_save_path=temp_dir,
+        delete_existing=True,
+        default_num_processes=5,
+    )
     ensemble.create(train_model, context=MultiGpuContext)
 
     print("Ensemble was successfully trained")

--- a/examples/multi_device.py
+++ b/examples/multi_device.py
@@ -9,8 +9,7 @@ import tensorflow
 import uncertainty_wizard as uwiz
 
 
-class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManager):
-
+class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManagerV2):
 
     @classmethod
     def file_path(cls) -> str:
@@ -32,10 +31,6 @@ class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManager):
             0: 2,
             1: 3
         }
-
-    @classmethod
-    def gpu_memory_limit(cls) -> int:
-        return 1500
 
 
 def train_model(model_id):

--- a/examples/multi_device.py
+++ b/examples/multi_device.py
@@ -11,6 +11,10 @@ import uncertainty_wizard as uwiz
 
 class MultiGpuContext(uwiz.models.ensemble_utils.DeviceAllocatorContextManager):
 
+    #
+    # def __init__(self, *args, **kwargs):
+    #     super().__init__()
+
     @classmethod
     def file_path(cls) -> str:
         return "temp-ensemble.txt"

--- a/uncertainty_wizard/models/ensemble_utils/__init__.py
+++ b/uncertainty_wizard/models/ensemble_utils/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "DynamicGpuGrowthContextManager",
     "NoneContextManager",
     "DeviceAllocatorContextManager",
+    "DeviceAllocatorContextManagerV2",
     "CpuOnlyContextManager",
     "SaveConfig",
 ]
@@ -10,6 +11,7 @@ __all__ = [
 from ._lazy_contexts import (
     CpuOnlyContextManager,
     DeviceAllocatorContextManager,
+    DeviceAllocatorContextManagerV2,
     DynamicGpuGrowthContextManager,
     EnsembleContextManager,
     NoneContextManager,

--- a/uncertainty_wizard/models/ensemble_utils/_lazy_contexts.py
+++ b/uncertainty_wizard/models/ensemble_utils/_lazy_contexts.py
@@ -228,8 +228,8 @@ class DeviceAllocatorContextManager(EnsembleContextManager, abc.ABC):
     the abstract methods.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, model_id: int, varargs: dict = None):
+        super().__init__(model_id, varargs)
         if not current_tf_version_is_older_than("2.10.0"):
             raise RuntimeError(
                 "The DeviceAllocatorContextManager is not compatible with tensorflow 2.10.0 "


### PR DESCRIPTION
Introduces a new class `DeviceAllocatorContextManagerV2` which does not require experimental APIs anymore and uses dynamic memory growth. It fully backwards compatible: just replacing the class extension form `DeviceAllocatorContextManagerV2` with `DeviceAllocatorContextManagerV2` does the full migration. The `gpu_memory_limit` function is not called anymore and can be removed. 

This closes #75 